### PR TITLE
fix: restart Waves animation loop on bfcache restoration

### DIFF
--- a/components/shadcn/Waves.jsx
+++ b/components/shadcn/Waves.jsx
@@ -281,17 +281,26 @@ const Waves = ({
       }
     }
 
+    function onPageShow(e) {
+      if (e.persisted) {
+        cancelAnimationFrame(frameIdRef.current);
+        frameIdRef.current = requestAnimationFrame(tick);
+      }
+    }
+
     setSize();
     setLines();
     frameIdRef.current = requestAnimationFrame(tick);
     window.addEventListener('resize', onResize);
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('touchmove', onTouchMove, { passive: false });
+    window.addEventListener('pageshow', onPageShow);
 
     return () => {
       window.removeEventListener('resize', onResize);
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('pageshow', onPageShow);
       cancelAnimationFrame(frameIdRef.current);
     };
   }, []);


### PR DESCRIPTION
When the browser restores a page from the Back/Forward Cache (bfcache),
requestAnimationFrame callbacks are suspended and never resumed. React's
useEffect does not re-run on bfcache restoration, so the animation loop
was permanently dead after pressing the back button.

Listen to the pageshow event and restart the rAF loop when
event.persisted is true (bfcache thaw), fixing the blank WavesBg.

https://claude.ai/code/session_01HJbK4cZHLXYAZiyDiW1vV4