### PR TITLE
Add interactive carousels and terminal/typewriter effects

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,12 @@
 import Navbar from "../../components/Navbar";
 import DottedSurface from "../../components/DottedSurface/DottedSurface";
+import Terminal from "../../components/Terminal";
+
+const story = [
+  "Club C.O.D.E. was founded by a group of students who believed that the best way to learn technology is by building things together. What started as a small study group has grown into a thriving community of developers, designers, and tech enthusiasts.",
+  "Our mission is simple: Collaborate, Organize, Divide, and Execute. We bring students together to work on real projects, learn new skills, and support each other along the way. Whether you are a complete beginner or an experienced developer, there is a place for you here.",
+  "Through hands-on workshops, team projects, and community events, we aim to bridge the gap between classroom learning and real-world experience.",
+];
 
 const Page = () => {
   return (
@@ -11,20 +18,7 @@ const Page = () => {
       <div className="min-h-screen px-6 py-16">
         <div className="max-w-5xl mx-auto">
           <h1 className="text-5xl font-bold font-mono mb-6 text-white">Our Story</h1>
-          <p className="font-mono text-lg text-zinc-200 mb-4">
-            Club C.O.D.E. was founded by a group of students who believed that the best way to learn
-            technology is by building things together. What started as a small study group has grown
-            into a thriving community of developers, designers, and tech enthusiasts.
-          </p>
-          <p className="font-mono text-lg text-zinc-200 mb-4">
-            Our mission is simple: Collaborate, Organize, Divide, and Execute. We bring students
-            together to work on real projects, learn new skills, and support each other along the way.
-            Whether you are a complete beginner or an experienced developer, there is a place for you here.
-          </p>
-          <p className="font-mono text-lg text-zinc-200 mb-4">
-            Through hands-on workshops, team projects, and community events, we aim to bridge the gap
-            between classroom learning and real-world experience.
-          </p>
+          <Terminal lines={story} title="our-story.txt — bash" />
         </div>
       </div>
     </>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,3 +3,36 @@
    themes: night --default;
  }
 
+/* One full 3D coin-flip; triggered on click or an occasional timer. */
+@keyframes coin-flip {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+.animate-coin-flip {
+  transform-style: preserve-3d;
+  animation: coin-flip 0.9s ease-in-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-coin-flip {
+    animation: none;
+  }
+}
+
+/* Blinking caret for the typewriter tagline. */
+@keyframes caret-blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,9 @@
 import type { SVGProps } from "react";
-import Image from "next/image";
 import Navbar from "../components/Navbar";
 import DottedSurface from "../components/DottedSurface/DottedSurface";
+import CodeCarousel from "../components/CodeCarousel";
+import Typewriter from "../components/Typewriter";
+import HomeIntro from "../components/HomeIntro";
 
 const DiscordIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
@@ -64,53 +66,28 @@ const page = () => {
         <DottedSurface />
       </div>
       <Navbar />
-      <main className="min-h-[calc(100vh-72px)] px-6 py-10 font-mono text-zinc-100 sm:px-8 lg:px-12">
-        <section className="mx-auto flex min-h-[calc(100vh-152px)] w-full max-w-6xl flex-col justify-between gap-12">
-          <div className="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:gap-16">
+      <main className="min-h-[calc(100vh-72px)] px-[clamp(1.5rem,5vw,4.5rem)] py-[clamp(2.5rem,6vh,5rem)] font-mono text-zinc-100">
+        <section className="mx-auto flex min-h-[calc(100vh-152px)] w-full max-w-6xl flex-col justify-between gap-[clamp(3.5rem,9vh,6rem)]">
+          <div className="grid items-center gap-[clamp(3rem,7vw,6rem)] lg:grid-cols-[1.05fr_0.95fr]">
             <div>
-              <h1 className="text-4xl font-bold tracking-normal text-zinc-100 sm:text-5xl">
+              <h1 className="text-[clamp(2rem,5vw,3.25rem)] font-bold leading-tight tracking-normal text-zinc-100">
                 Club C.O.D.E.
               </h1>
-              <p className="mt-4 text-lg text-zinc-400 sm:text-xl">
-                Collaborate. Organize. Divide. Execute.
-              </p>
+              <Typewriter
+                text="Collaborate. Organize. Divide. Execute."
+                loopDelay={4000}
+                className="mt-[clamp(1rem,2vw,1.75rem)] block text-[clamp(1rem,2vw,1.375rem)] text-[#3ab5fb]"
+              />
 
-              <div className="mt-12 space-y-8">
-                {codeValues.map((item) => (
-                  <div key={item.letter} className="grid grid-cols-[2.25rem_1fr] gap-4">
-                    <span className="text-3xl font-bold leading-none text-[#3ab5fb]">
-                      {item.letter}
-                    </span>
-                    <div>
-                      <h2 className="text-lg font-bold text-zinc-100">{item.title}</h2>
-                      <p className="mt-1 max-w-xl text-base leading-7 text-zinc-400">
-                        {item.description}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+              <div className="mt-[clamp(3rem,7vh,5rem)]">
+                <CodeCarousel values={codeValues} />
               </div>
             </div>
 
-            <div className="flex flex-col items-center gap-10 text-center">
-              <Image
-                src="/images/ClubCodeLogo.png"
-                alt="Club C.O.D.E. logo"
-                width={500}
-                height={500}
-                priority
-                className="size-56 rounded-full object-contain shadow-[0_0_0_6px_rgba(255,255,255,0.95),0_18px_60px_rgba(58,181,251,0.18)] sm:size-64"
-              />
-
-              <p className="max-w-md text-base leading-7 text-zinc-400 sm:text-lg">
-                Club C.O.D.E. is a student-run organization dedicated to fostering a
-                community of developers, designers, and tech enthusiasts. We build
-                projects, host events, and help each other grow.
-              </p>
-            </div>
+            <HomeIntro />
           </div>
 
-          <div className="flex flex-wrap justify-center gap-4">
+          <div className="flex flex-wrap justify-center gap-[clamp(1rem,2.5vw,2rem)]">
             {socialLinks.map(({ label, href, icon: Icon }) => (
               <a
                 key={label}

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,6 +1,6 @@
 import { teams, execs } from "../../lib/data";
 import TeamCard from "../../components/TeamCard";
-import ExecCard from "../../components/ExecCard";
+import ExecCarousel from "../../components/ExecCarousel";
 import Navbar from "../../components/Navbar";
 import DottedSurface from "../../components/DottedSurface/DottedSurface";
 
@@ -20,27 +20,20 @@ export default function TeamsPage() {
           <h1 className="text-center text-5xl font-bold text-zinc-50">
             Executive Board
           </h1>
-          <p className="text-center text-xl text-zinc-300 mb-3">
+          <p className="text-center text-xl text-zinc-300 mb-8">
             2026-2027
           </p>
 
-          <div className="grid grid-cols-4 gap-6">
-            {execs.map((exec) => (
-              <ExecCard key={exec.name} exec={exec} />
+          <ExecCarousel execs={execs} />
+
+          <section className="mt-16 space-y-6">
+            <h2 className="text-4xl font-bold font-mono text-center">
+              Teams
+            </h2>
+
+            {teams.map((t) => (
+              <TeamCard key={t.id} team={t} />
             ))}
-          </div>
-
-          <section className="mt-12">
-            <h2 className="text-2xl font-semibold text-zinc-50">Teams</h2>
-            <p className="mt-1 text-sm text-zinc-300">
-              Explore the groups within the club.
-            </p>
-
-            <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {teams.map((t) => (
-                <TeamCard key={t.id} team={t} />
-              ))}
-            </div>
           </section>
         </div>
       </div>

--- a/components/CodeCarousel.tsx
+++ b/components/CodeCarousel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Coverflow, { type CoverflowItem } from "./Coverflow";
+
+type CodeValue = {
+  letter: string;
+  title: string;
+  description: string;
+};
+
+export default function CodeCarousel({ values }: { values: CodeValue[] }) {
+  const items: CoverflowItem[] = values.map((v) => ({
+    key: v.letter,
+    label: `${v.letter} — ${v.title}`,
+    content: (
+      <div className="flex h-full flex-col items-center justify-center px-2">
+        <span className="text-[clamp(2.5rem,7vw,3.75rem)] font-bold leading-none text-[#3ab5fb]">
+          {v.letter}
+        </span>
+        <h2 className="mt-4 text-[clamp(1.25rem,3vw,1.5rem)] font-bold text-zinc-100">
+          {v.title}
+        </h2>
+        <p className="mt-3 text-[clamp(0.85rem,1.8vw,1rem)] leading-7 text-zinc-300">
+          {v.description}
+        </p>
+      </div>
+    ),
+  }));
+
+  return (
+    <Coverflow
+      items={items}
+      ariaLabel="Club C.O.D.E. values"
+      stageClassName="h-[clamp(280px,40vh,340px)]"
+      cardClassName="w-[clamp(220px,80%,300px)] h-[clamp(240px,36vh,280px)] flex"
+      prevArrowClassName="left-0 sm:-left-2"
+      nextArrowClassName="right-0 sm:-right-2"
+    />
+  );
+}

--- a/components/Coverflow.tsx
+++ b/components/Coverflow.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { cn } from "../lib/utils";
+
+const AUTOPLAY_MS = 4000;
+const DRAG_THRESHOLD = 60; // px of drag before a slide flips
+
+export type CoverflowItem = {
+  /** Stable key for the slide. */
+  key: string;
+  /** Accessible label announced for the slide. */
+  label: string;
+  /** Card contents. */
+  content: React.ReactNode;
+};
+
+type CoverflowProps = {
+  items: CoverflowItem[];
+  /** Accessible name for the whole carousel region. */
+  ariaLabel: string;
+  /** Height of the 3D stage. */
+  stageClassName?: string;
+  /** Width of each card. */
+  cardClassName?: string;
+  /** Horizontal position of the prev arrow (overrides the default offset). */
+  prevArrowClassName?: string;
+  /** Horizontal position of the next arrow (overrides the default offset). */
+  nextArrowClassName?: string;
+};
+
+/**
+ * A fluid 3D coverflow carousel: the focused card sits centered while
+ * neighbours fan out at depth on both sides. Supports drag/swipe, arrow
+ * buttons, clickable side cards, keyboard arrows, dot navigation, and
+ * autoplay that pauses on interaction. Infinite-looping.
+ */
+export default function Coverflow({
+  items,
+  ariaLabel,
+  stageClassName,
+  cardClassName,
+  prevArrowClassName = "left-2 sm:left-6",
+  nextArrowClassName = "right-2 sm:right-6",
+}: CoverflowProps) {
+  const count = items.length;
+  const [active, setActive] = useState(0);
+  const [paused, setPaused] = useState(false);
+
+  // Live drag state (in "slide units"; 1 == one full card width dragged).
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const widthRef = useRef(1);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  // Measure the stage so the fan-out spacing scales with available width:
+  // wide on desktop, tighter on phones so neighbours never run off-screen.
+  const [stageWidth, setStageWidth] = useState(0);
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) =>
+      setStageWidth(entry.contentRect.width)
+    );
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Fan distance per slide: ~38% of the stage width, clamped to a sane range.
+  const fan = Math.max(120, Math.min(stageWidth * 0.38, 240));
+
+  // Shortest signed distance from the active index to slide i, accounting for
+  // the infinite wrap so neighbours fan out on both sides near the edges.
+  const offsetFor = useCallback(
+    (i: number) => {
+      let d = i - active;
+      if (d > count / 2) d -= count;
+      if (d < -count / 2) d += count;
+      return d;
+    },
+    [active, count]
+  );
+
+  const go = useCallback(
+    (dir: number) => setActive((a) => (a + dir + count) % count),
+    [count]
+  );
+  const goTo = useCallback((i: number) => setActive(((i % count) + count) % count), [count]);
+
+  // Autoplay — paused on hover, focus, or active drag.
+  useEffect(() => {
+    if (paused || count <= 1) return;
+    const id = setInterval(() => go(1), AUTOPLAY_MS);
+    return () => clearInterval(id);
+  }, [paused, go, count]);
+
+  // Keyboard navigation when the carousel region is focused.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      go(-1);
+    } else if (e.key === "ArrowRight") {
+      e.preventDefault();
+      go(1);
+    }
+  };
+
+  // --- Pointer drag / swipe ---------------------------------------------
+  const onPointerDown = (e: React.PointerEvent) => {
+    dragging.current = true;
+    setIsDragging(true);
+    startX.current = e.clientX;
+    widthRef.current = trackRef.current?.offsetWidth ?? 1;
+    setPaused(true);
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    const dx = e.clientX - startX.current;
+    setDragOffset(dx / widthRef.current);
+  };
+
+  const endDrag = () => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    setIsDragging(false);
+    if (dragOffset <= -0.001 || dragOffset >= 0.001) {
+      const slidesMoved = Math.round(-dragOffset);
+      const passedThreshold =
+        Math.abs(dragOffset * widthRef.current) > DRAG_THRESHOLD;
+      const step = slidesMoved !== 0 ? slidesMoved : passedThreshold ? Math.sign(-dragOffset) : 0;
+      if (step !== 0) setActive((a) => (a + step + count) % count);
+    }
+    setDragOffset(0);
+    setPaused(false);
+  };
+
+  return (
+    <div
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={ariaLabel}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onFocus={() => setPaused(true)}
+      onBlur={() => setPaused(false)}
+      className="relative w-full select-none outline-none"
+    >
+      {/* Stage */}
+      <div
+        ref={trackRef}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        onPointerLeave={endDrag}
+        className={cn(
+          "relative mx-auto w-full cursor-grab touch-pan-y active:cursor-grabbing [perspective:1200px]",
+          stageClassName ?? "h-[360px]"
+        )}
+        style={{ transformStyle: "preserve-3d" }}
+      >
+        {items.map((item, i) => {
+          // Position relative to centre, including the live drag.
+          const pos = offsetFor(i) + dragOffset;
+          const abs = Math.abs(pos);
+          const visible = abs <= 2.5;
+
+          // Cards fan out: shift sideways, recede in depth, rotate, and fade.
+          // Spacing scales with the measured stage width (see `fan`).
+          const translateX = pos * fan;
+          const translateZ = -abs * fan * 0.95;
+          const rotateY = pos * -22;
+          const scale = Math.max(0.7, 1 - abs * 0.14);
+          const opacity = abs > 2.2 ? 0 : Math.max(0, 1 - abs * 0.32);
+          const isCenter = Math.abs(pos) < 0.5;
+
+          return (
+            <button
+              key={item.key}
+              type="button"
+              aria-label={item.label}
+              aria-hidden={!isCenter}
+              tabIndex={isCenter ? 0 : -1}
+              onClick={() => !isCenter && goTo(i)}
+              className={cn(
+                "absolute left-1/2 top-1/2 origin-center rounded-2xl border p-5 text-center font-mono text-white shadow-xl backdrop-blur-md",
+                "border-white/20 bg-white/5",
+                cardClassName ?? "w-[260px]",
+                isDragging
+                  ? "transition-none"
+                  : "transition-[transform,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                isCenter
+                  ? "ring-1 ring-white/40 shadow-[0_20px_60px_-15px_rgba(0,0,0,0.7)]"
+                  : "cursor-pointer hover:border-white/40"
+              )}
+              style={{
+                transform: `translate(-50%, -50%) translateX(${translateX}px) translateZ(${translateZ}px) rotateY(${rotateY}deg) scale(${scale})`,
+                opacity,
+                zIndex: 100 - Math.round(abs * 10),
+                pointerEvents: visible ? "auto" : "none",
+              }}
+            >
+              {item.content}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Arrow controls */}
+      <button
+        type="button"
+        aria-label="Previous slide"
+        onClick={() => go(-1)}
+        className={cn(
+          "absolute top-1/2 z-200 -translate-y-1/2 rounded-full border border-white/20 bg-white/10 p-2 text-white backdrop-blur-md transition hover:bg-white/25",
+          prevArrowClassName
+        )}
+      >
+        <ChevronLeft className="h-6 w-6" />
+      </button>
+      <button
+        type="button"
+        aria-label="Next slide"
+        onClick={() => go(1)}
+        className={cn(
+          "absolute top-1/2 z-200 -translate-y-1/2 rounded-full border border-white/20 bg-white/10 p-2 text-white backdrop-blur-md transition hover:bg-white/25",
+          nextArrowClassName
+        )}
+      >
+        <ChevronRight className="h-6 w-6" />
+      </button>
+
+      {/* Dot indicators */}
+      <div className="mt-6 flex items-center justify-center gap-2">
+        {items.map((item, i) => (
+          <button
+            key={item.key}
+            type="button"
+            aria-label={`Go to ${item.label}`}
+            aria-current={i === active}
+            onClick={() => goTo(i)}
+            className={cn(
+              "h-2 rounded-full transition-all duration-300",
+              i === active ? "w-6 bg-white" : "w-2 bg-white/30 hover:bg-white/60"
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ExecCarousel.tsx
+++ b/components/ExecCarousel.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { type Exec } from "../lib/data";
+import Coverflow, { type CoverflowItem } from "./Coverflow";
+
+export default function ExecCarousel({ execs }: { execs: Exec[] }) {
+  const items: CoverflowItem[] = execs.map((exec) => ({
+    key: exec.id,
+    label: `${exec.name}, ${exec.role}`,
+    content: (
+      <>
+        <h4 className="mb-4 text-xl tracking-wide text-zinc-100">{exec.role}</h4>
+        <img
+          src={exec.image}
+          alt={exec.name}
+          draggable={false}
+          className="mx-auto h-[180px] w-[180px] rounded-xl object-cover"
+        />
+        <p className="mt-4 text-lg font-semibold">{exec.name}</p>
+      </>
+    ),
+  }));
+
+  return <Coverflow items={items} ariaLabel="Executive board members" />;
+}

--- a/components/FlipLogo.tsx
+++ b/components/FlipLogo.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import { cn } from "../lib/utils";
+
+// How often the logo flips on its own. Kept long so it's an occasional
+// flourish, not a constant spin. Clicking flips it any time.
+const AUTO_FLIP_MS = 12000;
+
+export default function FlipLogo({ className }: { className?: string }) {
+  const [flipping, setFlipping] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const flip = useCallback(() => {
+    if (timeoutRef.current !== null) return; // ignore while mid-flip
+    setFlipping(true);
+    timeoutRef.current = window.setTimeout(() => {
+      setFlipping(false);
+      timeoutRef.current = null;
+    }, 900); // matches the CSS flip duration
+  }, []);
+
+  // Occasional automatic flip.
+  useEffect(() => {
+    const id = window.setInterval(flip, AUTO_FLIP_MS);
+    return () => window.clearInterval(id);
+  }, [flip]);
+
+  return (
+    <div className="[perspective:1000px]">
+      <Image
+        src="/images/ClubCodeLogo.png"
+        alt="Club C.O.D.E. logo"
+        width={500}
+        height={500}
+        priority
+        onClick={flip}
+        role="button"
+        tabIndex={0}
+        aria-label="Flip the Club C.O.D.E. logo"
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            flip();
+          }
+        }}
+        className={cn(
+          "aspect-square cursor-pointer rounded-full object-contain shadow-[0_0_0_6px_rgba(255,255,255,0.95),0_18px_60px_rgba(58,181,251,0.18)] [transform-style:preserve-3d] transition-[width] duration-700 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          className ?? "w-[clamp(11rem,22vw,18rem)]",
+          flipping && "animate-coin-flip"
+        )}
+      />
+    </div>
+  );
+}

--- a/components/HomeIntro.tsx
+++ b/components/HomeIntro.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import FlipLogo from "./FlipLogo";
+import Terminal from "./Terminal";
+
+const BLURB =
+  "Club C.O.D.E. is a student-run organization dedicated to fostering a community of developers, designers, and tech enthusiasts. We build projects, host events, and help each other grow.";
+
+/**
+ * Home page right column: the flip logo above the terminal blurb. Once the
+ * terminal finishes typing, the logo shrinks so the column's height settles —
+ * roughly aligning the terminal's bottom with the carousel nav in the left
+ * column.
+ */
+export default function HomeIntro() {
+  const [typed, setTyped] = useState(false);
+
+  return (
+    <div className="flex flex-col items-center gap-[clamp(2.5rem,5vh,4rem)] text-center">
+      <FlipLogo
+        className={
+          typed
+            ? "w-[clamp(8rem,15vw,12rem)]"
+            : "w-[clamp(11rem,22vw,18rem)]"
+        }
+      />
+
+      <Terminal
+        lines={[BLURB]}
+        title="clubcode.txt — bash"
+        className="w-full max-w-md text-left"
+        onDone={() => setTyped(true)}
+      />
+    </div>
+  );
+}

--- a/components/TeamCard.tsx
+++ b/components/TeamCard.tsx
@@ -3,17 +3,14 @@ import type { Team } from "../lib/data";
 
 export default function TeamCard({ team }: { team: Team }) {
   return (
-    <div className="rounded-lg border border-gray-100 bg-white p-4 shadow-sm dark:bg-zinc-900 dark:border-zinc-800">
-      <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{team.name}</h3>
-      
-      <div className="mt-3 text-sm text-zinc-700 dark:text-zinc-300">
-        <strong>Members:</strong>
-        <ul className="mt-1 ml-4 list-disc">
-          {team.members.map((m) => (
-            <li key={m}>{m}</li>
-          ))}
-        </ul>
+    <div className="rounded-3xl bg-base-200/10 backdrop-blur-md border border-white/20 p-7 shadow-lg transition duration-200 hover:scale-[1.03]">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-[22px] font-bold font-mono">{team.name}</h2>
+        <p className="text-right font-mono opacity-70 shrink-0">
+          {team.leads.join(", ")}
+        </p>
       </div>
+      <p className="text-sm mt-4 font-mono">{team.members.join(", ")}</p>
     </div>
   );
 }

--- a/components/Terminal.tsx
+++ b/components/Terminal.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type TerminalProps = {
+  /** Lines printed sequentially, each preceded by a prompt. */
+  lines: string[];
+  /** Title shown in the window's title bar. */
+  title?: string;
+  /** The prompt rendered before each line. */
+  prompt?: string;
+  /** ms between characters while typing. */
+  speed?: number;
+  className?: string;
+  /** Called once when every line has finished typing. */
+  onDone?: () => void;
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+export default function Terminal({
+  lines,
+  title = "about — bash",
+  prompt = "$",
+  speed = 22,
+  className,
+  onDone,
+}: TerminalProps) {
+  const total = lines.length;
+
+  // Which line is currently typing, and how many chars of it are shown.
+  // Initialised "complete" when the user prefers reduced motion.
+  const [line, setLine] = useState(() => (prefersReducedMotion() ? total : 0));
+  const [char, setChar] = useState(0);
+  const timeoutRef = useRef<number | null>(null);
+
+  const done = line >= total;
+
+  // Notify the parent exactly once when all lines have been typed.
+  const notifiedRef = useRef(false);
+  useEffect(() => {
+    if (done && !notifiedRef.current) {
+      notifiedRef.current = true;
+      onDone?.();
+    }
+  }, [done, onDone]);
+
+  useEffect(() => {
+    if (prefersReducedMotion() || done) return;
+
+    const current = lines[line];
+    if (char < current.length) {
+      timeoutRef.current = window.setTimeout(() => setChar((c) => c + 1), speed);
+    } else {
+      // Brief pause at end of line, then advance to the next one.
+      timeoutRef.current = window.setTimeout(() => {
+        setLine((l) => l + 1);
+        setChar(0);
+      }, 450);
+    }
+
+    return () => {
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    };
+  }, [line, char, lines, speed, done]);
+
+  return (
+    <div
+      className={
+        "overflow-hidden rounded-xl border border-white/20 bg-zinc-950/70 font-mono shadow-2xl backdrop-blur-md " +
+        (className ?? "")
+      }
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-2 border-b border-white/10 bg-white/5 px-4 py-3">
+        <span className="size-3 rounded-full bg-[#ff5f56]" />
+        <span className="size-3 rounded-full bg-[#ffbd2e]" />
+        <span className="size-3 rounded-full bg-[#27c93f]" />
+        <span className="ml-3 text-xs text-zinc-400">{title}</span>
+      </div>
+
+      {/* Body */}
+      <div className="space-y-4 p-5 text-left text-lg leading-8 text-zinc-200 sm:p-7">
+        {lines.map((text, i) => {
+          // A line is hidden until typing reaches it; the active line shows a
+          // partial slice; completed lines show in full.
+          if (!done && i > line) return null;
+          const shown = done || i < line ? text : text.slice(0, char);
+          const isActive = !done && i === line;
+          const isLast = done && i === total - 1;
+
+          return (
+            <p key={i} aria-label={text}>
+              <span className="mr-2 select-none text-[#27c93f]" aria-hidden="true">
+                {prompt}
+              </span>
+              <span aria-hidden="true">{shown}</span>
+              {(isActive || isLast) && (
+                <span
+                  aria-hidden="true"
+                  className="ml-0.5 inline-block w-px animate-[caret-blink_1s_steps(1)_infinite] self-stretch border-r-[0.6em] border-zinc-200 align-middle"
+                  style={{ height: "1.1em" }}
+                />
+              )}
+            </p>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/Typewriter.tsx
+++ b/components/Typewriter.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type TypewriterProps = {
+  /** The full string to type out. */
+  text: string;
+  /** ms between characters while typing. */
+  speed?: number;
+  /** ms to hold the full text before restarting (0 = type once, no loop). */
+  loopDelay?: number;
+  className?: string;
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+export default function Typewriter({
+  text,
+  speed = 70,
+  loopDelay = 0,
+  className,
+}: TypewriterProps) {
+  // When reduced motion is requested, start fully typed and never animate.
+  const [count, setCount] = useState(() =>
+    prefersReducedMotion() ? text.length : 0
+  );
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (prefersReducedMotion()) return;
+
+    if (count < text.length) {
+      timeoutRef.current = window.setTimeout(() => setCount((c) => c + 1), speed);
+    } else if (loopDelay > 0) {
+      timeoutRef.current = window.setTimeout(() => setCount(0), loopDelay);
+    }
+
+    return () => {
+      if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    };
+  }, [count, text, speed, loopDelay]);
+
+  return (
+    <span className={className} aria-label={text}>
+      <span aria-hidden="true">{text.slice(0, count)}</span>
+      <span
+        aria-hidden="true"
+        className="ml-0.5 inline-block w-px animate-[caret-blink_1s_steps(1)_infinite] self-stretch border-r-2 border-current align-middle"
+        style={{ height: "1em" }}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
- Add 3D coverflow carousel (Coverflow) with drag, keyboard, dots, autoplay
- Use it for the exec board (ExecCarousel) and home C.O.D.E. values (CodeCarousel)
- Restyle TeamCard to match the Events page glass UI
- Add typewriter tagline and click/auto-flip 3D logo on home
- Add typed terminal-window effect for the About story and home blurb